### PR TITLE
add "examples" page on documentation

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -21,7 +21,7 @@
     * [Modelling data](generate_adapter.md)
     * [Hive & Flutter](register_adapter.md)
     * [When to use Hive](type_adapters.md)
-
+* [Examples](examples.md)
 * [Browser support](browser.md)
 * [Frequently Asked Questions](faq.md)
 * [Limitations](limitations.md)

--- a/examples.md
+++ b/examples.md
@@ -1,0 +1,13 @@
+# Apps that show how to use Hive
+
+## Hive To-Do App
+ * Link to website: [Click Here](https://leisim.github.io/hive/demos/todo/)
+ * Link to Source Code: [Click Here](https://github.com/leisim/hive/tree/master/examples/todo)
+ 
+## Hive SketchPad
+ * Link to website: [Click Here](https://leisim.github.io/hive/demos/sketchpad/)
+ * Link to Source Code: [Click Here](https://github.com/leisim/hive/tree/master/examples/sketchpad)
+ 
+## Simple Counter
+ * Link to website: [Click Here](https://leisim.github.io/hive/demos/counter/)
+ * Link to Source Code: [Click Here](https://github.com/leisim/hive/tree/master/examples/counter)

--- a/examples.md
+++ b/examples.md
@@ -1,6 +1,6 @@
 # Apps that show how to use Hive
 
-## Hive To-Do App
+## Hive To-Do
  * Link to website: [Click Here](https://leisim.github.io/hive/demos/todo/)
  * Link to Source Code: [Click Here](https://github.com/leisim/hive/tree/master/examples/todo)
  


### PR DESCRIPTION
Hello again

sometimes when i am reading your docs, i want to go to the apps you made too see the code for myself.
Whenever i wanted this, it was necessary to open github, select you repo, navigate into the app folder...

This PR simplifies that problem.


But i want your opinion if it is a good way to put in documentation these links written "click here". If not, can you suggest me other way? i don't have any other idea, but i'm sure this can be better

also i am changing the `gh-pages` branch, don't know if it is the correct one. If is not, tell me.